### PR TITLE
Add glossary for terms used in taxonomy

### DIFF
--- a/en/_index.md
+++ b/en/_index.md
@@ -30,12 +30,15 @@ Cross-reference products and capabilities of many cloud providers.
 
 Contributions from the community are welcome.
   - Add content as pull request to [Github Repos](https://github.com/lexical-cloud)
-  - Submit [ideas or issues](https://github.com/lexical-cloud/lexical-cloud-docs-hugo/issues/) for existing content
+  - Submit ideas or issues for the [content](https://github.com/lexical-cloud/lexical-cloud-docs/issues) or [website](https://github.com/lexical-cloud/lexical-cloud-docs-hugo/issues/)
   - Spread word about this project
 
 {{< alert title="Attribution" >}}
  * Amazon Web Services, AWS, and associated products are trademarks of Amazon.com, Inc. or its affiliates.
+ * CNCF and the CNCF logo design are registered trademarks of the Cloud Native Computing Foundation.
  * GitHub and associated products are trademarks of GitHub, Inc.
  * Google, Google Cloud, and associated products are trademarks of Google LLC.
  * Microsoft Azure and associated products are trademarks of the Microsoft group of companies.
+
+Lexical.cloud is not affiliated with or otherwise sponsored by any of the above organizations. No relationship is implied or intended by references or links to their content. Please [file an issue](https://github.com/lexical-cloud/lexical-cloud-docs/issues/) to report any discrepancy. 
 {{< /alert >}}

--- a/en/docs/compute/aws/ec2-auto-scaling.md
+++ b/en/docs/compute/aws/ec2-auto-scaling.md
@@ -1,8 +1,13 @@
 ---
-services: "compute"
-providers: "aws"
+services:
+  - "compute"
+providers:
+  - "aws"
+domains:
+  - "virtualization"
 categories: 
   - "virtual machines"
+features:
   - "auto scaling"
 title: "Amazon EC2 Auto Scaling"
 linkTitle: "Amazon EC2 Auto Scaling"

--- a/en/docs/compute/aws/ec2.md
+++ b/en/docs/compute/aws/ec2.md
@@ -1,7 +1,12 @@
 ---
-services: "compute"
-providers: "aws"
-categories: "virtual machines"
+services:
+  - "compute"
+providers:
+  - "aws"
+domains:
+  - "virtualization"
+categories:
+  - "virtual machines"
 title: "Amazon Elastic Compute Cloud"
 linkTitle: "Amazon EC2"
 ---

--- a/en/docs/compute/aws/ecs.md
+++ b/en/docs/compute/aws/ecs.md
@@ -1,7 +1,12 @@
 ---
-services: "compute"
-providers: "aws"
-categories: "container orchestrator"
+services:
+  -  "compute"
+providers:
+  - "aws"
+domains:
+  - "containerization"
+categories:
+  -  "container orchestrator"
 title: "Amazon Elastic Container Service"
 linkTitle: "Amazon ECS"
 ---

--- a/en/docs/compute/aws/eks.md
+++ b/en/docs/compute/aws/eks.md
@@ -6,6 +6,7 @@ providers:
 domains:
   - "containerization"
 categories:
+  - "container orchestrator"
   - "kubernetes"
 title: "Amazon Elastic Kubernetes Service"
 linkTitle: "Amazon EKS"

--- a/en/docs/compute/aws/eks.md
+++ b/en/docs/compute/aws/eks.md
@@ -1,7 +1,12 @@
 ---
-services: "compute"
-providers: "aws"
-categories: "kubernetes"
+services:
+  - "compute"
+providers:
+  - "aws"
+domains:
+  - "containerization"
+categories:
+  - "kubernetes"
 title: "Amazon Elastic Kubernetes Service"
 linkTitle: "Amazon EKS"
 ---

--- a/en/docs/compute/aws/fargate.md
+++ b/en/docs/compute/aws/fargate.md
@@ -1,9 +1,13 @@
 ---
-services: "compute"
-providers: "aws"
+services:
+  - "compute"
+providers:
+  - "aws"
+domains:
+  - "containerization"
+  - "serverless"
 categories:
   - "container orchestrator"
-  - "serverless"
 title: "AWS Fargate"
 linkTitle: "AWS Fargate"
 ---

--- a/en/docs/compute/aws/lambda.md
+++ b/en/docs/compute/aws/lambda.md
@@ -1,7 +1,12 @@
 ---
-services: "compute"
-providers: "aws"
-categories: "serverless"
+services:
+  -  "compute"
+providers:
+  - "aws"
+domains:
+  - "serverless"
+categories:
+  - "faas"
 title: "AWS Lambda"
 linkTitle: "AWS Lambda"
 ---

--- a/en/docs/compute/azure/aks.md
+++ b/en/docs/compute/azure/aks.md
@@ -6,6 +6,7 @@ providers:
 domains:
   -"containerization"
 categories:
+  - "container orchestrator"
   - "kubernetes"
 title: "Azure Kubernetes Service"
 linkTitle: "Azure Kubernetes Service"

--- a/en/docs/compute/azure/aks.md
+++ b/en/docs/compute/azure/aks.md
@@ -1,7 +1,12 @@
 ---
-services: "compute"
-providers: "azure"
-categories: "kubernetes"
+services:
+  - "compute"
+providers:
+  - "azure"
+domains:
+  -"containerization"
+categories:
+  - "kubernetes"
 title: "Azure Kubernetes Service"
 linkTitle: "Azure Kubernetes Service"
 ---

--- a/en/docs/compute/azure/container-apps.md
+++ b/en/docs/compute/azure/container-apps.md
@@ -1,6 +1,10 @@
 ---
-services: "compute"
-providers: "azure"
+services:
+  - "compute"
+providers:
+  - "azure"
+domains:
+  - "containerization"
 categories:
   - "container orchestrator"
   - "serverless"

--- a/en/docs/compute/azure/container-instances.md
+++ b/en/docs/compute/azure/container-instances.md
@@ -1,7 +1,12 @@
 ---
-services: "compute"
-providers: "azure"
-categories: "container management"
+services:
+  - "compute"
+providers:
+  - "azure"
+domains:
+  - "containerization"
+categories:
+  - "container management"
 title: "Azure Container Instances"
 linkTitle: "Azure Container Instances"
 ---

--- a/en/docs/compute/azure/functions.md
+++ b/en/docs/compute/azure/functions.md
@@ -1,7 +1,12 @@
 ---
-services: "compute"
-providers: "azure"
-categories: "serverless"
+services:
+  - "compute"
+providers:
+  - "azure"
+domains:
+  - "serverless"
+categories:
+  - "faas"
 title: "Azure Functions"
 linkTitle: "Azure Functions"
 ---

--- a/en/docs/compute/azure/service-fabric.md
+++ b/en/docs/compute/azure/service-fabric.md
@@ -1,7 +1,12 @@
 ---
-services: "compute"
-providers: "azure"
-categories: "container orchestrator"
+services:
+  - "compute"
+providers:
+  - "azure"
+domains:
+  - "containerization"
+categories:
+  - "container orchestrator"
 title: "Azure Service Fabric"
 linkTitle: "Azure Service Fabric"
 ---

--- a/en/docs/compute/azure/vm-scaled-sets.md
+++ b/en/docs/compute/azure/vm-scaled-sets.md
@@ -1,8 +1,13 @@
 ---
-services: "compute"
-providers: "azure"
+services:
+  - "compute"
+providers:
+  - "azure"
+domains:
+  - "virtualization"
 categories: 
   - "virtual machines"
+features:
   - "auto scaling"
 title: "Azure Virtual Machine Scaled Sets"
 linkTitle: "Azure VM Scaled Sets"

--- a/en/docs/compute/azure/vm.md
+++ b/en/docs/compute/azure/vm.md
@@ -1,7 +1,12 @@
 ---
-services: "compute"
-providers: "azure"
-categories: "virtual machines"
+services:
+  - "compute"
+providers:
+  - "azure"
+domains:
+  - "virtualization"
+categories:
+  - "virtual machines"
 title: "Azure Virtual Machines"
 linkTitle: "Azure Virtual Machines"
 ---

--- a/en/docs/compute/gcp/cloud-functions.md
+++ b/en/docs/compute/gcp/cloud-functions.md
@@ -1,7 +1,12 @@
 ---
-services: "compute"
-providers: "gcp"
-categories: "serverless"
+services:
+  - "compute"
+providers:
+  - "gcp"
+domains:
+  - "serverless"
+categories:
+  - "faas"
 title: "Google Cloud Functions"
 linkTitle: "Google Cloud Functions"
 ---

--- a/en/docs/compute/gcp/cloud-run.md
+++ b/en/docs/compute/gcp/cloud-run.md
@@ -1,9 +1,13 @@
 ---
-services: "compute"
-providers: "gcp"
+services:
+  - "compute"
+providers:
+  - "gcp"
+domains:
+  - "containerization"
+  - "serverless"
 categories:
   - "container orchestrator"
-  - "serverless"
 title: "Google Cloud Run"
 linkTitle: "Google Cloud Run"
 ---

--- a/en/docs/compute/gcp/compute-engine.md
+++ b/en/docs/compute/gcp/compute-engine.md
@@ -1,7 +1,12 @@
 ---
-services: "compute"
-providers: "gcp"
-categories: "virtual machines"
+services:
+  - "compute"
+providers:
+  - "gcp"
+domains:
+  - "virtualization"
+categories:
+  - "virtual machines"
 title: "Google Cloud Compute Engine"
 linkTitle: "Google Cloud Compute Engine"
 ---

--- a/en/docs/compute/gcp/gke.md
+++ b/en/docs/compute/gcp/gke.md
@@ -1,7 +1,12 @@
 ---
-services: "compute"
-providers: "gcp"
-categories: "kubernetes"
+services:
+  - "compute"
+providers:
+  - "gcp"
+domains:
+  - "containerization"
+categories:
+  -  "kubernetes"
 title: "Google Kubernetes Engine"
 linkTitle: "Google Kubernetes Engine"
 ---

--- a/en/docs/compute/gcp/gke.md
+++ b/en/docs/compute/gcp/gke.md
@@ -6,7 +6,8 @@ providers:
 domains:
   - "containerization"
 categories:
-  -  "kubernetes"
+  - "container orchestrator"
+  - "kubernetes"
 title: "Google Kubernetes Engine"
 linkTitle: "Google Kubernetes Engine"
 ---

--- a/en/docs/compute/gcp/managed-instance-groups.md
+++ b/en/docs/compute/gcp/managed-instance-groups.md
@@ -1,8 +1,13 @@
 ---
-services: "compute"
-providers: "gcp"
+services:
+  - "compute"
+providers:
+  - "gcp"
+domains:
+  - "virtualization"
 categories: 
   - "virtual machines"
+features:
   - "auto scaling"
 title: "Google Cloud Managed Instance Groups"
 linkTitle: "Google Cloud Managed Instance Groups"

--- a/en/docs/developer-tool/aws/opsworks.md
+++ b/en/docs/developer-tool/aws/opsworks.md
@@ -1,9 +1,12 @@
 ---
-services: "developer-tool"
-providers: "aws"
+services:
+  - "developer-tool"
+providers:
+  -  "aws"
+domains:
+  - "virtualization"
 categories:
   - "configuration management"
-domains: "virtual machines"
 title: "AWS OpsWorks"
 linkTitle: "AWS OpsWorks"
 ---

--- a/en/docs/governance/aws/license-manager.md
+++ b/en/docs/governance/aws/license-manager.md
@@ -1,9 +1,12 @@
 ---
-services: "governance"
-providers: "aws"
+services:
+  - "governance"
+providers:
+  - "aws"
+domains:
+  - "virtualization"
 categories:
   - "license management"
-domains: "virtual machines"
 title: "AWS License Manager"
 linkTitle: "AWS License Manager"
 ---

--- a/en/docs/monitor/aws/inspector.md
+++ b/en/docs/monitor/aws/inspector.md
@@ -1,10 +1,13 @@
 ---
-services: "monitor"
-providers: "aws"
+services:
+  - "monitor"
+providers:
+  - "aws"
+domains:
+  - "virtualization"
 categories:
   - "vulnerability management"
   - "assessment"
-domains: "virtual machines"
 features: "agent-based"
 title: "Amazon Inspector"
 linkTitle: "Amazon Inspector"

--- a/en/docs/security/aws/security-group.md
+++ b/en/docs/security/aws/security-group.md
@@ -2,11 +2,12 @@
 services:
   - "security"
   - "compute"
-providers: "aws"
+providers:
+  - "aws"
+domains:
+  - "virtualization" 
 categories: 
   - "firewall"
-domains:
-  - "virtual machines" 
 features:
   - "stateful"
 title: "Amazon EC2 Security Group"

--- a/en/glossary/_index.md
+++ b/en/glossary/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Lexical.cloud"
+linkTitle: "Lexical.cloud"
+weight: 20
+type: glossary
+---

--- a/en/glossary/api-gateway.md
+++ b/en/glossary/api-gateway.md
@@ -1,0 +1,4 @@
+---
+title: "API Gateway"
+definitionLink: "https://glossary.cncf.io/api-gateway/"
+---

--- a/en/glossary/api-gateway.md
+++ b/en/glossary/api-gateway.md
@@ -1,4 +1,5 @@
 ---
 title: "API Gateway"
+linkTitle: "api gateway"
 definitionLink: "https://glossary.cncf.io/api-gateway/"
 ---

--- a/en/glossary/auto-scaling.md
+++ b/en/glossary/auto-scaling.md
@@ -1,5 +1,6 @@
 ---
 title: "Auto Scaling"
+linkTitle: "auto scaling"
 definitionLink: "https://glossary.cncf.io/auto-scaling/"
 domains:
   - "virtualization"

--- a/en/glossary/auto-scaling.md
+++ b/en/glossary/auto-scaling.md
@@ -1,0 +1,6 @@
+---
+title: "Auto Scaling"
+definitionLink: "https://glossary.cncf.io/auto-scaling/"
+domains:
+  - "virtualization"
+---

--- a/en/glossary/container-orchestrator.md
+++ b/en/glossary/container-orchestrator.md
@@ -1,0 +1,6 @@
+---
+title: "Container Orchestrator"
+linkTitle: "container orchestrator"
+domains:
+  - "containerization"
+---

--- a/en/glossary/containerization.md
+++ b/en/glossary/containerization.md
@@ -1,0 +1,4 @@
+---
+title: "Containerization"
+definitionLink: "https://glossary.cncf.io/containerization/"
+---

--- a/en/glossary/containerization.md
+++ b/en/glossary/containerization.md
@@ -1,4 +1,5 @@
 ---
 title: "Containerization"
+linkTitle: "containerization"
 definitionLink: "https://glossary.cncf.io/containerization/"
 ---

--- a/en/glossary/continuous-delivery.md
+++ b/en/glossary/continuous-delivery.md
@@ -1,4 +1,5 @@
 ---
 title: "Continuous Delivery"
+linkTitle: "continuous delivery"
 definitionLink: "https://glossary.cncf.io/continuous-delivery/"
 ---

--- a/en/glossary/continuous-delivery.md
+++ b/en/glossary/continuous-delivery.md
@@ -1,0 +1,4 @@
+---
+title: "Continuous Delivery"
+definitionLink: "https://glossary.cncf.io/continuous-delivery/"
+---

--- a/en/glossary/continuous-deployment.md
+++ b/en/glossary/continuous-deployment.md
@@ -1,0 +1,4 @@
+---
+title: "Continuous Deployment"
+definitionLink: "https://glossary.cncf.io/continuous-deployment/"
+---

--- a/en/glossary/continuous-deployment.md
+++ b/en/glossary/continuous-deployment.md
@@ -1,4 +1,5 @@
 ---
 title: "Continuous Deployment"
+linkTitle: "continuous deployment"
 definitionLink: "https://glossary.cncf.io/continuous-deployment/"
 ---

--- a/en/glossary/continuous-integration.md
+++ b/en/glossary/continuous-integration.md
@@ -1,4 +1,5 @@
 ---
 title: "Continuous Integration"
+linkTitle: "continuous integration"
 definitionLink: "https://glossary.cncf.io/continuous-integration/"
 ---

--- a/en/glossary/continuous-integration.md
+++ b/en/glossary/continuous-integration.md
@@ -1,0 +1,4 @@
+---
+title: "Continuous Integration"
+definitionLink: "https://glossary.cncf.io/continuous-integration/"
+---

--- a/en/glossary/devops.md
+++ b/en/glossary/devops.md
@@ -1,0 +1,4 @@
+---
+title: "DevOps"
+definitionLink: "https://glossary.cncf.io/devops/"
+---

--- a/en/glossary/devops.md
+++ b/en/glossary/devops.md
@@ -1,4 +1,5 @@
 ---
 title: "DevOps"
+linkTitle: "devops"
 definitionLink: "https://glossary.cncf.io/devops/"
 ---

--- a/en/glossary/faas.md
+++ b/en/glossary/faas.md
@@ -1,4 +1,7 @@
 ---
 title: "Function as a Service (FaaS)"
+linkTitle: "faas"
 definitionLink: "https://glossary.cncf.io/function-as-a-service/"
+domains:
+  - "serverless"
 ---

--- a/en/glossary/faas.md
+++ b/en/glossary/faas.md
@@ -1,0 +1,4 @@
+---
+title: "Function as a Service (FaaS)"
+definitionLink: "https://glossary.cncf.io/function-as-a-service/"
+---

--- a/en/glossary/firewall.md
+++ b/en/glossary/firewall.md
@@ -1,4 +1,5 @@
 ---
 title: "Firewall"
+linkTitle: "firewall"
 definitionLink: "https://glossary.cncf.io/firewall/"
 ---

--- a/en/glossary/firewall.md
+++ b/en/glossary/firewall.md
@@ -1,0 +1,4 @@
+---
+title: "Firewall"
+definitionLink: "https://glossary.cncf.io/firewall/"
+---

--- a/en/glossary/iaas.md
+++ b/en/glossary/iaas.md
@@ -1,0 +1,4 @@
+---
+title: "Infrastructure as a Service (IaaS)"
+definitionLink: "https://glossary.cncf.io/infrastructure-as-a-service/"
+---

--- a/en/glossary/iaas.md
+++ b/en/glossary/iaas.md
@@ -1,4 +1,5 @@
 ---
 title: "Infrastructure as a Service (IaaS)"
+linkTitle: "iaas"
 definitionLink: "https://glossary.cncf.io/infrastructure-as-a-service/"
 ---

--- a/en/glossary/iac.md
+++ b/en/glossary/iac.md
@@ -1,0 +1,4 @@
+---
+title: "Infrastructure as Code (IaC)"
+definitionLink: "https://glossary.cncf.io/infrastructure-as-code/"
+---

--- a/en/glossary/iac.md
+++ b/en/glossary/iac.md
@@ -1,4 +1,5 @@
 ---
 title: "Infrastructure as Code (IaC)"
+linkTitle: "iac"
 definitionLink: "https://glossary.cncf.io/infrastructure-as-code/"
 ---

--- a/en/glossary/kubernetes.md
+++ b/en/glossary/kubernetes.md
@@ -1,0 +1,9 @@
+---
+title: "Kubernetes"
+linkTitle: "kubernetes"
+definitionLink: "https://glossary.cncf.io/kubernetes/"
+domains:
+  - "containerization"
+categories:
+  - "container orchestrator"
+---

--- a/en/glossary/observability.md
+++ b/en/glossary/observability.md
@@ -1,0 +1,4 @@
+---
+title: "Observability"
+definitionLink: "https://glossary.cncf.io/observability/"
+---

--- a/en/glossary/observability.md
+++ b/en/glossary/observability.md
@@ -1,4 +1,5 @@
 ---
 title: "Observability"
+linkTitle: "observability"
 definitionLink: "https://glossary.cncf.io/observability/"
 ---

--- a/en/glossary/serverless.md
+++ b/en/glossary/serverless.md
@@ -1,4 +1,5 @@
 ---
 title: "Serverless"
+linkTitle: "serverless"
 definitionLink: "https://glossary.cncf.io/serverless/"
 ---

--- a/en/glossary/serverless.md
+++ b/en/glossary/serverless.md
@@ -1,0 +1,4 @@
+---
+title: "Serverless"
+definitionLink: "https://glossary.cncf.io/serverless/"
+---

--- a/en/glossary/virtual-machine.md
+++ b/en/glossary/virtual-machine.md
@@ -1,0 +1,6 @@
+---
+title: "Virtual Machine"
+definitionLink: "https://glossary.cncf.io/virtual-machine/"
+domains:
+  - "virtualization"
+---

--- a/en/glossary/virtual-machines.md
+++ b/en/glossary/virtual-machines.md
@@ -1,5 +1,6 @@
 ---
-title: "Virtual Machine"
+title: "Virtual Machines"
+linkTitle: "virtual machines"
 definitionLink: "https://glossary.cncf.io/virtual-machine/"
 domains:
   - "virtualization"

--- a/en/glossary/virtualization.md
+++ b/en/glossary/virtualization.md
@@ -1,0 +1,4 @@
+---
+title: "Virtualization"
+definitionLink: "https://glossary.cncf.io/virtualization/"
+---

--- a/en/glossary/virtualization.md
+++ b/en/glossary/virtualization.md
@@ -1,4 +1,5 @@
 ---
 title: "Virtualization"
+linkTitle: "virtualization"
 definitionLink: "https://glossary.cncf.io/virtualization/"
 ---


### PR DESCRIPTION
Aligns terms for taxonomy in content to glossary. (resolves #1 and #2)
  - Introduce glossary entry for each term
  - Link to definition in external source for each term
  - Build consistency in existing entries
    - Use terms from established sources
    - Format attributes of content data as list when appropriate
    - Backfill domains attribute when missing
    - Distinguish features from categories where necessary